### PR TITLE
Rebuilt ETL MVP

### DIFF
--- a/mETL/database.py
+++ b/mETL/database.py
@@ -23,22 +23,24 @@ class Database(object):
 
         return pg.connect(host=self.host, port=self.port, database=self.database, user=self.user)
 
-    def execute(self, sql_string):
+    def execute(self, sql_string, connection=None, cursor=None):
         """
         Opens a connection to this database, executes the given SQL string, then closes the connection
         :return: The psycopg connection and cursor objects
         """
 
-        conn = self.connect()
-        cur = conn.cursor()
-        cur.execute(sql_string)
-
-        return conn, cur
+        if not connection:
+            connection = self.connect()
+        if not cursor:
+            cursor = connection.cursor()
+        try:
+            cursor.execute(sql_string)
+            return connection, cursor
+        except pg.Error as e:
+            cursor.close()
+            raise e
 
     @staticmethod
-    def commit_and_close(conn, cur):
-        conn.commit()
-        cur.close()
-
-
-
+    def commit_and_close(connection, cursor):
+        connection.commit()
+        cursor.close()

--- a/mETL/etl/transform.py
+++ b/mETL/etl/transform.py
@@ -1,0 +1,36 @@
+from model import Model
+
+
+class Transform(Model):
+    def __init__(self, table_name, schema_name='transformed', source_tables=None):
+        Model.__init__(self, table_name=table_name, schema_name=schema_name)
+        if source_tables is None:
+            self.source_tables = []
+        else:
+            self.source_tables = source_tables
+
+    def transform(self):
+        # all subclasses must define
+        pass
+
+    def recalculate_sql(self):
+        recalculate_string = 'with '
+
+        subq_array = []
+        for table in self.source_tables:
+            subq = '{name} as (select * from {schema}.{name})'.format(name=table.table_name,
+                                                                      schema=table.schema_name)
+            subq_array.append(subq)
+
+        recalculate_string += ', '.join(subq_array)
+        recalculate_string += ' '
+        recalculate_string += self.transform()
+        return recalculate_string
+
+    def create_sql(self):
+        return 'create table {schema}.{table} as ({recalculate_sql})'.format(schema=self.schema_name,
+                                                                             table=self.table_name,
+                                                                             recalculate_sql=self.recalculate_sql())
+
+    def insert_sql(self, **kwargs):
+        pass

--- a/mETL/hello_world_transform.py
+++ b/mETL/hello_world_transform.py
@@ -1,6 +1,7 @@
 from etl.raw_model import RawModel
 from etl.transform_database import TransformDatabase
 from column_data_type import IntegerColumn, TextColumn
+from etl.transform import Transform
 
 
 def level_zero():
@@ -18,5 +19,37 @@ def level_zero():
     test_database.process_queue_message(message)
 
 
+def level_one():
+    class ColorsDatabase(TransformDatabase):
+
+        class Colors(RawModel):
+            id = IntegerColumn()
+            name = TextColumn()
+
+        class Users(RawModel):
+            id = IntegerColumn()
+            name = TextColumn()
+            favorite_color_id = IntegerColumn()
+
+        color_table = Colors(table_name='colors')
+        user_table = Users(table_name='users')
+
+        class FavoriteColors(Transform):
+            def transform(self):
+                return '''
+                    select users.id as user_id, users.name, favorite_color_id, colors.name as favorite_color_name
+                    from colors
+                    join users
+                    on colors.id = users.favorite_color_id
+                '''
+
+        favorite_colors = FavoriteColors(table_name='favorite_colors', source_tables=[color_table, user_table])
+
+    colors_database = ColorsDatabase(queue_name='mETL.fifo', database='metl')
+    colors_database.create_all_tables()
+
+    message = colors_database.queue.read_from_queue()
+    colors_database.process_queue_message(message)
+
 if __name__ == '__main__':
-    level_zero()
+    level_one()

--- a/mETL/hello_world_write.py
+++ b/mETL/hello_world_write.py
@@ -19,6 +19,10 @@ def level_zero():
 
 def level_one():
     class TestTable(WriteModel):
+        def __init__(self):
+            metl_queue = Queue('mETL.fifo')
+            WriteModel.__init__(self, database=Database(queue=metl_queue, database='mETL'), table_name='test_table')
+
         num_col = IntegerColumn()
         text_col = TextColumn()
 
@@ -35,6 +39,10 @@ def level_one():
 
 def level_two():
     class TestTable(WriteModel):
+        def __init__(self):
+            metl_queue = Queue('mETL.fifo')
+            WriteModel.__init__(self, database=Database(queue=metl_queue, database='metl'), table_name='test_table')
+
         num_col = IntegerColumn()
         text_col = TextColumn()
 
@@ -43,5 +51,30 @@ def level_two():
     test_table.insert(num_col=0, text_col='hello world')
 
 
+def level_three():
+    class Colors(WriteModel):
+        id = IntegerColumn()
+        name = TextColumn()
+
+    class Users(WriteModel):
+        id = IntegerColumn()
+        name = TextColumn()
+        favorite_color_id = IntegerColumn()
+
+    color_table = Colors(database=Database(queue_name='mETL.fifo', database='metl'), table_name='colors')
+    user_table = Users(database=Database(queue_name='mETL.fifo', database='metl'), table_name='users')
+    color_table.create()
+    user_table.create()
+    color_table.insert(id=0, name='red')
+    color_table.insert(id=1, name='orange')
+    color_table.insert(id=2, name='yellow')
+    color_table.insert(id=3, name='green')
+    color_table.insert(id=4, name='blue')
+    color_table.insert(id=5, name='purple')
+    user_table.insert(id=0, name='Rachel', favorite_color_id=4)
+    user_table.insert(id=1, name='Matt', favorite_color_id=4)
+    user_table.insert(id=2, name='Josh', favorite_color_id=3)
+
+
 if __name__ == '__main__':
-    level_two()
+    level_three()

--- a/mETL/model.py
+++ b/mETL/model.py
@@ -3,7 +3,7 @@ class Model(object):
     Superclass for defining the schema of a table
     """
 
-    def __init__(self, table_name, schema_name='public'):
+    def __init__(self, table_name, schema_name):
         self.table_name = table_name
         self.schema_name = schema_name
 
@@ -15,13 +15,15 @@ class Model(object):
         """
 
         create_string = '''
-            CREATE TABLE {schema_name}.{table_name}(
+            CREATE TABLE IF NOT EXISTS {schema_name}.{table_name}(
         '''.format(schema_name=self.schema_name, table_name=self.table_name)
+
         col_array = []
         for column in self.__class__.__dict__:
             if not column.startswith('__'):
                 column_obj = getattr(self, column)
                 col_array.append('{name} {data_type}'.format(name=column, data_type=column_obj.postgres_name))
+
         create_string += ', '.join(col_array)
         create_string += ')'
         return create_string
@@ -35,15 +37,17 @@ class Model(object):
 
         insert_string = '''
             INSERT INTO {schema_name}.{table_name}(
-            '''.format(schema_name=self.schema_name, table_name=self.table_name)
+        '''.format(schema_name=self.schema_name, table_name=self.table_name)
+
         col_array = []
-        value_array = []
+        val_array = []
         for key, value in kwargs.iteritems():
             col_array.append(key)
             value = "'{value}'".format(value=str(value))
-            value_array.append(value)
+            val_array.append(value)
+
         insert_string += ', '.join(col_array)
         insert_string += ') VALUES ('
-        insert_string += ', '.join(value_array)
+        insert_string += ', '.join(val_array)
         insert_string += ')'
         return insert_string

--- a/mETL/queue.py
+++ b/mETL/queue.py
@@ -1,5 +1,6 @@
 import boto3
 from config import read_params
+import random
 
 
 class Queue(object):
@@ -27,11 +28,14 @@ class Queue(object):
         self.sqs_queue.send_message(
             MessageAttributes=data,
             MessageGroupId='mETL',
-            MessageBody='mETL insert data'
+            MessageBody='mETL insert data',
+            MessageDeduplicationId=str(random.getrandbits(128))
         )
 
     def read_from_queue(self):
         messages = self.sqs_queue.receive_messages(MaxNumberOfMessages=1, MessageAttributeNames=['.*'])
         if len(messages) != 0:
             message = messages[0]
-            return message.message_attributes
+            return message
+        else:
+            raise ValueError('No messages returned from queue {queue}'.format(queue=self.queue_name))

--- a/mETL/write/write_model.py
+++ b/mETL/write/write_model.py
@@ -21,6 +21,8 @@ class WriteModel(Model):
     def insert(self, **kwargs):
         """
         Execute the insertion SQL against the given database
+        Don't commit the db operation until the queue has been written to successfully to ensure
+        the queue and database stay in sync
         """
 
         conn, cur = self.database.execute(self.insert_sql(**kwargs))


### PR DESCRIPTION
We can now define a transform! Transforms are defined as Postgres SQL strings for now.

Right now the transform is being updated by being entirely recalculated every time a message is read from the queue. The next step is to be able to update it in an incremental way!